### PR TITLE
23-implement-configurable-origin-validation-for-websocket-connections

### DIFF
--- a/src/Core/Server.php
+++ b/src/Core/Server.php
@@ -81,10 +81,10 @@ class Server
     /**
      * Server constructor
      * 
-     * @param string      $host        Host address to bind server to
-     * @param int         $port        Port to bind server to
-     * @param bool        $debug       Enable debug mode with verbose output
-     * @param array       $corsConfig  CORS configuration options
+     * @param string      $host          Host address to bind server to
+     * @param int         $port          Port to bind server to
+     * @param bool        $debug         Enable debug mode with verbose output
+     * @param array       $corsConfig    CORS configuration options
      */
     public function __construct(
         string $host = "0.0.0.0", 
@@ -93,7 +93,7 @@ class Server
         array $corsConfig = []
     ) {
         $this->router = new Router();
-        $this->wsHandler = new WebSocketHandler($this);
+        $this->wsHandler = new WebSocketHandler($this, $corsConfig['allowed_origins'] ?? []);
         $this->httpHandler = new HttpHandler($this, $corsConfig);
         $this->namespaceManager = new NamespaceManager();
         $this->middleware = new Middleware();


### PR DESCRIPTION
This pull request introduces support for restricting WebSocket connections based on allowed origins, enhancing security by enabling Cross-Origin Resource Sharing (CORS) configuration. The key changes include modifications to the `WebSocketHandler` to handle allowed origins, updates to the handshake process to validate origins, and adjustments to server initialization to pass CORS configuration.

### WebSocket origin restriction:

* [`src/WebSocket/WebSocketHandler.php`](diffhunk://#diff-017f4d5f108b6f57e3e65d052c18ef6b2ed50fcfe3fbe19e04f202689071b809R30-R60): Added a new `allowedOrigins` property and updated the constructor to accept an array of allowed origins. Introduced the `isOriginAllowed` method to validate if a WebSocket connection's origin is permitted.
* [`src/WebSocket/WebSocketHandler.php`](diffhunk://#diff-017f4d5f108b6f57e3e65d052c18ef6b2ed50fcfe3fbe19e04f202689071b809R119-R129): Updated the `performHandshake` method to check the origin of incoming WebSocket connections. If the origin is not allowed, the connection is rejected with a 403 Forbidden response.
* [`src/WebSocket/WebSocketHandler.php`](diffhunk://#diff-017f4d5f108b6f57e3e65d052c18ef6b2ed50fcfe3fbe19e04f202689071b809R142-R145): Modified the handshake response to include the `Access-Control-Allow-Origin` header if the origin is allowed.

### Server initialization updates:

* [`src/Core/Server.php`](diffhunk://#diff-7da72ab25976c73d455f5ec6470a7ba4d3a78ae38a2be4701741128530401312L96-R96): Updated the `WebSocketHandler` initialization to pass the `allowed_origins` from the CORS configuration, ensuring the server enforces the defined origin restrictions.