### PR TITLE
implement-multi-room-dispatching

### DIFF
--- a/src/Core/Contracts/EventableContract.php
+++ b/src/Core/Contracts/EventableContract.php
@@ -4,14 +4,31 @@ namespace Sockeon\Sockeon\Core\Contracts;
 
 interface EventableContract
 {
+    /**
+     * Get the name of the event for broadcasting.
+     *
+     * @return string
+     */
     public function broadcastAs(): string;
 
     /**
+     * Get the data to be broadcast with the event.
+     * 
      * @return array<mixed>
      */
     public function broadcastWith(): array;
 
-    public function broadcastRoom(): ?string;
+    /**
+     * Get the rooms to broadcast the event to.
+     * 
+     * @return array<string>|null
+     */
+    public function broadcastOn(): ?array;
 
+    /**
+     * Get the namespace for the broadcast.
+     *
+     * @return string|null
+     */
     public function broadcastNamespace(): ?string;
 }

--- a/src/Core/Event.php
+++ b/src/Core/Event.php
@@ -36,16 +36,18 @@ final class Event
         try {
             $eventName = $event->broadcastAs();
             $data = $event->broadcastWith();
-            $room = $event->broadcastRoom() ?? null;
+            $rooms = $event->broadcastOn() ?? [];
             $namespace = $event->broadcastNamespace() ?? '/';
 
-            self::writeToQueue([
-                'type' => 'broadcast',
-                'event' => $eventName,
-                'data' => $data,
-                'namespace' => $namespace,
-                'room' => $room,
-            ]);
+            foreach ($rooms as $room) {
+                self::writeToQueue([
+                    'type' => 'broadcast',
+                    'event' => $eventName,
+                    'data' => $data,
+                    'namespace' => $namespace,
+                    'room' => $room,
+                ]);
+            }
         } catch (Throwable $e) {
             error_log('Error broadcasting event: ' . $e->getMessage());
         }


### PR DESCRIPTION
This pull request introduces enhancements to the event broadcasting system by updating the `EventableContract` interface and modifying the `broadcast` method in the `Event` class. These changes improve flexibility and scalability by supporting broadcasting to multiple rooms and refining the structure of the broadcast data.

### Updates to the `EventableContract` interface:

* Added new method `broadcastOn()` to retrieve an array of rooms for broadcasting instead of a single room. This allows events to target multiple rooms.
* Introduced `broadcastNamespace()` method to specify the namespace for the broadcast, improving organization and separation of event channels.

### Modifications to the `broadcast` method in `Event` class:

* Replaced the single room handling (`broadcastRoom`) with support for broadcasting to multiple rooms using the new `broadcastOn()` method.
* Added a loop to iterate over rooms and queue individual broadcasts for each room, enhancing scalability for multi-room broadcasting.