### PR TITLE
authentication-framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Welcome to Sockeon! A framework-agnostic PHP WebSocket and HTTP server library t
 - RESTful API support with content negotiation
 - Namespaces and rooms support for WebSocket communication
 - Middleware support for authentication and request processing
+- Key-based WebSocket authentication for secure connections
 - Zero dependencies - built with PHP core functionality only
 - Easy-to-use event-based architecture
 - Real-time bidirectional communication

--- a/src/Connection/Server.php
+++ b/src/Connection/Server.php
@@ -115,6 +115,7 @@ class Server
      * @param array<string, mixed> $corsConfig CORS configuration options
      * @param LoggerInterface|null $logger Custom logger implementation
      * @param string|null $queueFile Custom queue file path
+     * @param string|null $authKey Authentication key for WebSocket connections (null to disable authentication)
      * @throws Throwable
      */
     public function __construct(
@@ -123,7 +124,8 @@ class Server
         bool $debug = false,
         array $corsConfig = [],
         ?LoggerInterface $logger = null,
-        ?string $queueFile = null
+        ?string $queueFile = null,
+        ?string $authKey = null
     ) {
         $this->host = $host;
         $this->port = $port;
@@ -134,6 +136,10 @@ class Server
         
         if ($queueFile) {
             Config::setQueueFile($queueFile);
+        }
+        
+        if ($authKey !== null) {
+            Config::setAuthKey($authKey);
         }
 
         $this->logger = $logger ?? new Logger(

--- a/src/Core/Config.php
+++ b/src/Core/Config.php
@@ -28,6 +28,7 @@ class Config
         if (empty(self::$config)) {
             self::$config = [
                 'queue_file' => self::getDefaultQueueFilePath(),
+                'auth_key' => null,
             ];
         }
     }
@@ -101,10 +102,33 @@ class Config
      * 
      * @return array<string, mixed> All configuration values
      */
-    public static function all(): array
+    public static function getAll(): array
     {
         self::init();
         return self::$config;
+    }
+
+    /**
+     * Set the authentication key for WebSocket connections
+     * 
+     * @param string|null $key The authentication key (null to disable authentication)
+     * @return void
+     */
+    public static function setAuthKey(?string $key): void
+    {
+        self::init();
+        self::$config['auth_key'] = $key;
+    }
+
+    /**
+     * Get the authentication key for WebSocket connections
+     * 
+     * @return string|null The authentication key (null if authentication is disabled)
+     */
+    public static function getAuthKey(): ?string
+    {
+        self::init();
+        return self::$config['auth_key'] ?? null;
     }
 
     /**
@@ -115,7 +139,8 @@ class Config
     public static function reset(): void
     {
         self::$config = [
-            'queue_file' => self::getDefaultQueueFilePath()
+            'queue_file' => self::getDefaultQueueFilePath(),
+            'auth_key' => null,
         ];
     }
 


### PR DESCRIPTION
This pull request introduces key-based WebSocket authentication to enhance security for WebSocket connections. The changes include updates to the configuration system, the `Server` class, and the WebSocket handshake process to support authentication using a configurable key.

### WebSocket Authentication Enhancements:

* **Added authentication key support in `README.md`**: Updated the feature list to include key-based WebSocket authentication for secure connections.
* **Updated `Server` class constructor**: Added an optional `authKey` parameter to the constructor and integrated it into the configuration system. [[1]](diffhunk://#diff-7d68f1d0adfce2c5ee952785b63c61f4b7d1438dd659720cdceea1f5db8a03e5R118) [[2]](diffhunk://#diff-7d68f1d0adfce2c5ee952785b63c61f4b7d1438dd659720cdceea1f5db8a03e5L126-R128) [[3]](diffhunk://#diff-7d68f1d0adfce2c5ee952785b63c61f4b7d1438dd659720cdceea1f5db8a03e5R141-R144)
* **Extended `Config` class**: Added methods to set and retrieve the authentication key (`setAuthKey` and `getAuthKey`), and updated default configuration values to include the `auth_key` field. [[1]](diffhunk://#diff-0aac5061d5298ddd467333501b3b0ccfcfc057b55d8362a8ed20ddac8e6d0458R31) [[2]](diffhunk://#diff-0aac5061d5298ddd467333501b3b0ccfcfc057b55d8362a8ed20ddac8e6d0458L104-R133) [[3]](diffhunk://#diff-0aac5061d5298ddd467333501b3b0ccfcfc057b55d8362a8ed20ddac8e6d0458L118-R143)
* **Implemented authentication in WebSocket handshake**: Modified the `performHandshake` method in `Handler` to validate the authentication key passed in the WebSocket connection's query string. Unauthorized connections receive a 401 response. [[1]](diffhunk://#diff-1ba97e85e5c787d5f51a7a63b5b2b690941d23c1373d32da700ff5e0d355512aR15) [[2]](diffhunk://#diff-1ba97e85e5c787d5f51a7a63b5b2b690941d23c1373d32da700ff5e0d355512aR135-R158)