### PR TITLE
fix-post-body-parsing-issue

### DIFF
--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -246,7 +246,7 @@ class Request
     /**
      * Get request body as array (similar to Laravel's all() method)
      * 
-     * @return array<string, mixed> The request body as an array
+     * @return array<mixed, mixed> The request body as an array
      */
     public function all(): array
     {

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -244,6 +244,27 @@ class Request
     }
 
     /**
+     * Get request body as array (similar to Laravel's all() method)
+     * 
+     * @return array<string, mixed> The request body as an array
+     */
+    public function all(): array
+    {
+        if (is_array($this->body)) {
+            return $this->body;
+        }
+        
+        if (is_string($this->body) && !empty($this->body)) {
+            $decoded = json_decode($this->body, true);
+            if (json_last_error() === JSON_ERROR_NONE && is_array($decoded)) {
+                return $decoded;
+            }
+        }
+        
+        return [];
+    }
+
+    /**
      * Check if the request has a JSON content type
      * 
      * @return bool True if request has JSON content type
@@ -373,5 +394,67 @@ class Request
     public function getData(string $key, mixed $default = null): mixed
     {
         return $this->rawData[$key] ?? $default;
+    }
+
+    /**
+     * Magic method to access request data as properties
+     * Checks body data first, then query parameters
+     * 
+     * @param string $name The property name
+     * @return mixed The property value or null
+     */
+    public function __get(string $name): mixed
+    {
+        $bodyData = $this->all();
+        if (array_key_exists($name, $bodyData)) {
+            return $bodyData[$name];
+        }
+        
+        if (array_key_exists($name, $this->query)) {
+            return $this->query[$name];
+        }
+        
+        if (array_key_exists($name, $this->params)) {
+            return $this->params[$name];
+        }
+        
+        return null;
+    }
+
+    /**
+     * Magic method to check if a property exists
+     * 
+     * @param string $name The property name
+     * @return bool True if the property exists
+     */
+    public function __isset(string $name): bool
+    {
+        $bodyData = $this->all();
+        return array_key_exists($name, $bodyData) || 
+               array_key_exists($name, $this->query) || 
+               array_key_exists($name, $this->params);
+    }
+
+    /**
+     * Get a specific input value (body, query, or path parameter)
+     * 
+     * @param string $key The input key
+     * @param mixed $default Default value if key doesn't exist
+     * @return mixed The input value or default
+     */
+    public function input(string $key, mixed $default = null): mixed
+    {
+        return $this->__get($key) ?? $default;
+    }
+
+    /**
+     * Check if a specific input exists
+     * 
+     * @param string $key The input key
+     * @return bool True if the input exists
+     */
+    public function has(string $key): bool
+    {
+        return $this->__isset($key);
     }
 }

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -378,7 +378,7 @@ class Request
      * @param mixed $value The data value
      * @return self For method chaining
      */
-    public function setData(string $key, mixed $value): self
+    public function setAttribute(string $key, mixed $value): self
     {
         $this->rawData[$key] = $value;
         return $this;
@@ -391,7 +391,7 @@ class Request
      * @param mixed $default Default value if key doesn't exist
      * @return mixed The data value or default
      */
-    public function getData(string $key, mixed $default = null): mixed
+    public function getAttribute(string $key, mixed $default = null): mixed
     {
         return $this->rawData[$key] ?? $default;
     }

--- a/src/Traits/Http/HandlesHttpRequests.php
+++ b/src/Traits/Http/HandlesHttpRequests.php
@@ -70,15 +70,6 @@ trait HandlesHttpRequests
         if (isset($url['query'])) {
             parse_str($url['query'], $query);
         }
-
-        if (empty($body)) {
-            $body = [];
-        } else {
-            $parsedBody = json_decode($body, true);
-            if (json_last_error() === JSON_ERROR_NONE) {
-                $body = $parsedBody;
-            }
-        }
         
         return [
             'method' => $method,

--- a/src/Traits/Http/HandlesHttpRequests.php
+++ b/src/Traits/Http/HandlesHttpRequests.php
@@ -71,9 +71,13 @@ trait HandlesHttpRequests
             parse_str($url['query'], $query);
         }
 
-        $parsedBody = json_decode($body, true);
-        if (json_last_error() === JSON_ERROR_NONE) {
-            $body = $parsedBody;
+        if (empty($body)) {
+            $body = [];
+        } else {
+            $parsedBody = json_decode($body, true);
+            if (json_last_error() === JSON_ERROR_NONE) {
+                $body = $parsedBody;
+            }
         }
         
         return [


### PR DESCRIPTION
This pull request introduces enhancements to the `Http\Request` class, focusing on improving how request data is accessed and manipulated. The changes include adding new methods for working with request inputs, renaming methods for clarity, and introducing magic methods for property-like access to request data. Additionally, redundant JSON decoding logic has been removed from the `HandlesHttpRequests` trait.

### Enhancements to request data handling:

* **New `all` method**: Added a method to retrieve the request body as an array, decoding JSON if necessary. (`src/Http/Request.php`, [src/Http/Request.phpR246-R266](diffhunk://#diff-5b0abd27be147410f447740b27f69d68b4a25214a5a87a6366070a79dad4c7b3R246-R266))
* **Magic methods for property access**: Introduced `__get` and `__isset` to allow accessing request data (body, query, or parameters) as object properties. (`src/Http/Request.php`, [src/Http/Request.phpL373-R459](diffhunk://#diff-5b0abd27be147410f447740b27f69d68b4a25214a5a87a6366070a79dad4c7b3L373-R459))
* **New `input` and `has` methods**: Added methods to retrieve specific input values or check their existence across body, query, and path parameters. (`src/Http/Request.php`, [src/Http/Request.phpL373-R459](diffhunk://#diff-5b0abd27be147410f447740b27f69d68b4a25214a5a87a6366070a79dad4c7b3L373-R459))

### Method renaming for clarity:

* **Renamed `setData` to `setAttribute`**: Updated method name to better reflect its purpose of setting an attribute in the request data. (`src/Http/Request.php`, [src/Http/Request.phpL360-R381](diffhunk://#diff-5b0abd27be147410f447740b27f69d68b4a25214a5a87a6366070a79dad4c7b3L360-R381))
* **Renamed `getData` to `getAttribute`**: Updated method name for consistency with `setAttribute`. (`src/Http/Request.php`, [src/Http/Request.phpL373-R459](diffhunk://#diff-5b0abd27be147410f447740b27f69d68b4a25214a5a87a6366070a79dad4c7b3L373-R459))

### Code simplification:

* **Removed redundant JSON decoding**: Eliminated unnecessary logic for decoding JSON in the `HandlesHttpRequests` trait, as this functionality is now handled by the `all` method in `Http\Request`. (`src/Traits/Http/HandlesHttpRequests.php`, [src/Traits/Http/HandlesHttpRequests.phpL74-L78](diffhunk://#diff-12bd7ef7cf55d0cc88bd9de5b0cbe78e533586dc644f19af3fd23b7ecf1baabdL74-L78))