### PR TITLE
implement-exclude-route-and-event-for-global-middlewares

### DIFF
--- a/src/Core/Router.php
+++ b/src/Core/Router.php
@@ -39,13 +39,13 @@ class Router
     use HandlesHttpDispatching, HandlesMiddlewareValidation, HandlesRouteRegistration, HandlesWebSocketDispatching;
     /**
      * WebSocket routes
-     * @var array<string, array{0: SocketController, 1: string, 2: array<int, class-string>}>
+     * @var array<string, array{0: SocketController, 1: string, 2: array<int, class-string>, 3: array<int, class-string>}>
      */
     protected array $wsRoutes = [];
 
     /**
      * HTTP routes
-     * @var array<string, array{0: SocketController, 1: string, 2: array<int, class-string>}>
+     * @var array<string, array{0: SocketController, 1: string, 2: array<int, class-string>, 3: array<int, class-string>}>
      */
     protected array $httpRoutes = [];
 

--- a/src/Http/Attributes/HttpRoute.php
+++ b/src/Http/Attributes/HttpRoute.php
@@ -27,10 +27,12 @@ class HttpRoute
      * @param string $method The HTTP method (GET, POST, PUT, DELETE, etc.)
      * @param string $path The URL path to handle, can include path parameters like {id}
      * @param array<int, class-string> $middlewares Optional array of middleware class names to apply to this route
+     * @param array<int, class-string> $excludeGlobalMiddlewares Optional array of global middleware class names to exclude for this route
      */
     public function __construct(
         public string $method,
         public string $path,
         public array $middlewares = [],
+        public array $excludeGlobalMiddlewares = [],
     ) {}
 }

--- a/src/Traits/Router/HandlesHttpDispatching.php
+++ b/src/Traits/Router/HandlesHttpDispatching.php
@@ -54,13 +54,13 @@ trait HandlesHttpDispatching
     /**
      * Execute an HTTP route handler with middleware
      * 
-     * @param array{0: \Sockeon\Sockeon\Controllers\SocketController, 1: string, 2: array<int, class-string>} $handler The controller and method to call
+     * @param array{0: \Sockeon\Sockeon\Controllers\SocketController, 1: string, 2: array<int, class-string>, 3: array<int, class-string>} $handler The controller and method to call
      * @param Request $request The Request object
      * @return mixed The response from the handler
      */
     private function executeHttpRoute(array $handler, Request $request): mixed
     {
-        [$controller, $method, $middlewares] = $handler;
+        [$controller, $method, $middlewares, $excludeGlobalMiddlewares] = $handler;
 
         $this->validateHttpMiddlewares($middlewares);
 
@@ -71,7 +71,8 @@ trait HandlesHttpDispatching
                     return $controller->$method($request);
                 },
                 $this->server,
-                $middlewares
+                $middlewares,
+                $excludeGlobalMiddlewares
             );
         } else {
             return $controller->$method($request);
@@ -108,7 +109,7 @@ trait HandlesHttpDispatching
     /**
      * Get all registered HTTP routes
      * 
-     * @return array<string, array{0: \Sockeon\Sockeon\Controllers\SocketController, 1: string}> The registered HTTP routes
+     * @return array<string, array{0: \Sockeon\Sockeon\Controllers\SocketController, 1: string, 2: array<int, class-string>, 3: array<int, class-string>}> The registered HTTP routes
      */
     public function getHttpRoutes(): array
     {

--- a/src/Traits/Router/HandlesRouteRegistration.php
+++ b/src/Traits/Router/HandlesRouteRegistration.php
@@ -34,8 +34,9 @@ trait HandlesRouteRegistration
 
         foreach ($ref->getMethods() as $method) {
             foreach ($method->getAttributes(SocketOn::class) as $attr) {
-                $event = $attr->newInstance()->event;
-                $this->wsRoutes[$event] = [$controller, $method->getName(), $attr->newInstance()->middlewares];
+                $attrInstance = $attr->newInstance();
+                $event = $attrInstance->event;
+                $this->wsRoutes[$event] = [$controller, $method->getName(), $attrInstance->middlewares, $attrInstance->excludeGlobalMiddlewares];
             }
             
             foreach ($method->getAttributes(OnConnect::class) as $attr) {
@@ -49,7 +50,7 @@ trait HandlesRouteRegistration
             foreach ($method->getAttributes(HttpRoute::class) as $attr) {
                 $httpAttr = $attr->newInstance();
                 $key = $httpAttr->method . ' ' . $httpAttr->path;
-                $this->httpRoutes[$key] = [$controller, $method->getName(), $httpAttr->middlewares];
+                $this->httpRoutes[$key] = [$controller, $method->getName(), $httpAttr->middlewares, $httpAttr->excludeGlobalMiddlewares];
             }
         }
     }

--- a/src/Traits/Router/HandlesWebSocketDispatching.php
+++ b/src/Traits/Router/HandlesWebSocketDispatching.php
@@ -26,7 +26,7 @@ trait HandlesWebSocketDispatching
     public function dispatch(int $clientId, string $event, array $data): void
     {
         if (isset($this->wsRoutes[$event])) {
-            [$controller, $method, $middlewares] = $this->wsRoutes[$event];
+            [$controller, $method, $middlewares, $excludeGlobalMiddlewares] = $this->wsRoutes[$event];
 
             $this->validateWebsocketMiddlewares($middlewares);
 
@@ -39,7 +39,8 @@ trait HandlesWebSocketDispatching
                         return $controller->$method($clientId, $data);
                     },
                     $this->server,
-                    $middlewares
+                    $middlewares,
+                    $excludeGlobalMiddlewares
                 );
             } else {
                 $controller->$method($clientId, $data);

--- a/src/WebSocket/Attributes/SocketOn.php
+++ b/src/WebSocket/Attributes/SocketOn.php
@@ -23,9 +23,13 @@ class SocketOn
      * 
      * @param string $event  The event name
      * @param array<int, class-string> $middlewares List of middleware classes to apply to this event handler
+     * @param array<int, class-string> $excludeGlobalMiddlewares List of global middleware classes to exclude for this event handler
      */
-    public function __construct(public string $event, public array $middlewares = [])
-    {
+    public function __construct(
+        public string $event, 
+        public array $middlewares = [], 
+        public array $excludeGlobalMiddlewares = []
+    ) {
         //
     }
 }

--- a/tests/Unit/ExcludeMiddlewareTest.php
+++ b/tests/Unit/ExcludeMiddlewareTest.php
@@ -1,0 +1,220 @@
+<?php
+
+use Sockeon\Sockeon\Connection\Server;
+use Sockeon\Sockeon\Controllers\SocketController;
+use Sockeon\Sockeon\Contracts\Http\HttpMiddleware;
+use Sockeon\Sockeon\Contracts\WebSocket\WebsocketMiddleware;
+use Sockeon\Sockeon\Http\Attributes\HttpRoute;
+use Sockeon\Sockeon\Http\Request;
+use Sockeon\Sockeon\WebSocket\Attributes\SocketOn;
+
+class TestGlobalHttpMiddleware implements HttpMiddleware
+{
+    public static array $calls = [];
+
+    public function handle(Request $request, callable $next, Server $server): mixed
+    {
+        self::$calls[] = 'global_http';
+        return $next($request);
+    }
+}
+
+class TestGlobalWebSocketMiddleware implements WebsocketMiddleware
+{
+    public static array $calls = [];
+
+    public function handle(int $clientId, string $event, array $data, callable $next, Server $server): mixed
+    {
+        self::$calls[] = 'global_ws';
+        return $next();
+    }
+}
+
+class TestRouteSpecificHttpMiddleware implements HttpMiddleware
+{
+    public static array $calls = [];
+
+    public function handle(Request $request, callable $next, Server $server): mixed
+    {
+        self::$calls[] = 'route_specific_http';
+        return $next($request);
+    }
+}
+
+class TestRouteSpecificWebSocketMiddleware implements WebsocketMiddleware
+{
+    public static array $calls = [];
+
+    public function handle(int $clientId, string $event, array $data, callable $next, Server $server): mixed
+    {
+        self::$calls[] = 'route_specific_ws';
+        return $next();
+    }
+}
+
+beforeEach(function () {
+    TestGlobalHttpMiddleware::$calls = [];
+    TestGlobalWebSocketMiddleware::$calls = [];
+    TestRouteSpecificHttpMiddleware::$calls = [];
+    TestRouteSpecificWebSocketMiddleware::$calls = [];
+});
+
+test('websocket event can exclude global middleware', function () {
+    /** @var Server $server */
+    $server = $this->server; //@phpstan-ignore-line
+
+    $server->addWebSocketMiddleware(TestGlobalWebSocketMiddleware::class);
+
+    $controller = new class extends SocketController {
+        /**
+         * @param int $clientId
+         * @param array<string, mixed> $data
+         * @return bool
+         */
+        #[SocketOn('test.normal')]
+        public function normalEvent(int $clientId, array $data): bool
+        {
+            return true;
+        }
+
+        /**
+         * @param int $clientId
+         * @param array<string, mixed> $data
+         * @return bool
+         */
+        #[SocketOn('test.excluded', middlewares: [TestRouteSpecificWebSocketMiddleware::class], excludeGlobalMiddlewares: [TestGlobalWebSocketMiddleware::class])]
+        public function excludedEvent(int $clientId, array $data): bool
+        {
+            return true;
+        }
+    };
+
+    $server->registerController($controller);
+
+    $server->getRouter()->dispatch(1, 'test.normal', []);
+    expect(TestGlobalWebSocketMiddleware::$calls)->toContain('global_ws');
+
+    TestGlobalWebSocketMiddleware::$calls = [];
+    TestRouteSpecificWebSocketMiddleware::$calls = [];
+
+    $server->getRouter()->dispatch(1, 'test.excluded', []);
+    expect(TestGlobalWebSocketMiddleware::$calls)->toBeEmpty();
+    expect(TestRouteSpecificWebSocketMiddleware::$calls)->toContain('route_specific_ws');
+});
+
+test('http route can exclude global middleware', function () {
+    /** @var Server $server */
+    $server = $this->server; //@phpstan-ignore-line
+
+    $server->addHttpMiddleware(TestGlobalHttpMiddleware::class);
+
+    $controller = new class extends SocketController {
+        /**
+         * @param Request $request
+         * @return array<string, mixed>
+         */
+        #[HttpRoute('GET', '/normal')]
+        public function normalRoute(Request $request): array
+        {
+            return ['status' => 'normal'];
+        }
+
+        /**
+         * @param Request $request
+         * @return array<string, mixed>
+         */
+        #[HttpRoute('GET', '/excluded', middlewares: [TestRouteSpecificHttpMiddleware::class], excludeGlobalMiddlewares: [TestGlobalHttpMiddleware::class])]
+        public function excludedRoute(Request $request): array
+        {
+            return ['status' => 'excluded'];
+        }
+    };
+
+    $server->registerController($controller);
+
+    $request1 = new Request([
+        'method' => 'GET',
+        'path' => '/normal',
+        'headers' => [],
+        'query' => []
+    ]);
+    $server->getRouter()->dispatchHttp($request1);
+    expect(TestGlobalHttpMiddleware::$calls)->toContain('global_http');
+
+    TestGlobalHttpMiddleware::$calls = [];
+    TestRouteSpecificHttpMiddleware::$calls = [];
+
+    $request2 = new Request([
+        'method' => 'GET',
+        'path' => '/excluded',
+        'headers' => [],
+        'query' => []
+    ]);
+    $server->getRouter()->dispatchHttp($request2);
+    expect(TestGlobalHttpMiddleware::$calls)->toBeEmpty();
+    expect(TestRouteSpecificHttpMiddleware::$calls)->toContain('route_specific_http');
+});
+
+test('multiple middlewares can be excluded', function () {
+    /** @var Server $server */
+    $server = $this->server; //@phpstan-ignore-line
+
+    $server->addWebSocketMiddleware(TestGlobalWebSocketMiddleware::class);
+    $server->addWebSocketMiddleware(TestRouteSpecificWebSocketMiddleware::class);
+
+    $controller = new class extends SocketController {
+        /**
+         * @param int $clientId
+         * @param array<string, mixed> $data
+         * @return bool
+         */
+        #[SocketOn('test.exclude-multiple', excludeGlobalMiddlewares: [TestGlobalWebSocketMiddleware::class, TestRouteSpecificWebSocketMiddleware::class])]
+        public function excludeMultipleEvent(int $clientId, array $data): bool
+        {
+            return true;
+        }
+    };
+
+    $server->registerController($controller);
+
+    $server->getRouter()->dispatch(1, 'test.exclude-multiple', []);
+    expect(TestGlobalWebSocketMiddleware::$calls)->toBeEmpty();
+    expect(TestRouteSpecificWebSocketMiddleware::$calls)->toBeEmpty();
+});
+
+test('partial exclusion works correctly', function () {
+    /** @var Server $server */
+    $server = $this->server; //@phpstan-ignore-line
+
+    $anotherGlobalMiddleware = new class implements WebsocketMiddleware {
+        public static array $calls = [];
+
+        public function handle(int $clientId, string $event, array $data, callable $next, Server $server): mixed
+        {
+            self::$calls[] = 'another_global_ws';
+            return $next();
+        }
+    };
+
+    $server->addWebSocketMiddleware(TestGlobalWebSocketMiddleware::class);
+    $server->addWebSocketMiddleware($anotherGlobalMiddleware::class);
+
+    $controller = new class extends SocketController {
+        /**
+         * @param int $clientId
+         * @param array<string, mixed> $data
+         * @return bool
+         */
+        #[SocketOn('test.partial-exclude', excludeGlobalMiddlewares: [TestGlobalWebSocketMiddleware::class])]
+        public function partialExcludeEvent(int $clientId, array $data): bool
+        {
+            return true;
+        }
+    };
+
+    $server->registerController($controller);
+
+    $server->getRouter()->dispatch(1, 'test.partial-exclude', []);
+    expect(TestGlobalWebSocketMiddleware::$calls)->toBeEmpty();
+    expect($anotherGlobalMiddleware::$calls)->toContain('another_global_ws');
+});


### PR DESCRIPTION
This pull request introduces functionality to exclude specific global middlewares from being applied to individual HTTP routes and WebSocket events. It also includes updates to the middleware processing logic, route definitions, and dispatch mechanisms to support this feature. Unit tests have been added to ensure the correctness of the implementation.

### Middleware Filtering Enhancements:
* Added a new parameter `excludeGlobalMiddlewares` to middleware-related methods (`runWebSocketStack`, `runHttpStack`) to allow exclusion of specific global middlewares. (`src/Core/Middleware.php`) [[1]](diffhunk://#diff-bd196d038aa84e97c3710133ada35b2825beef4f4653b1bad01f45585a1a29baR94-R100) [[2]](diffhunk://#diff-bd196d038aa84e97c3710133ada35b2825beef4f4653b1bad01f45585a1a29baR129-R135)
* Introduced a private method `filterExcludedMiddlewares` to filter out excluded middlewares from the global stack. (`src/Core/Middleware.php`)

### Route and Attribute Updates:
* Updated WebSocket and HTTP route definitions to include `excludeGlobalMiddlewares` as part of their metadata. (`src/Core/Router.php`, `src/Http/Attributes/HttpRoute.php`, `src/WebSocket/Attributes/SocketOn.php`) [[1]](diffhunk://#diff-1796c9aab9b237682ebed3573d6f1adc7387254f9824356cc0e10e27903039ebL42-R48) [[2]](diffhunk://#diff-dd3b4e8596bcbd6a57103c5d9a50066d782b7df06289e7dfc4a0f07b85f45be7R30-R36) [[3]](diffhunk://#diff-2e25b095bdac865d323a0fa269c307738b1cf335bb74db0c8176607d2386a282R26-R32)
* Modified route registration logic to handle the new `excludeGlobalMiddlewares` attribute. (`src/Traits/Router/HandlesRouteRegistration.php`) [[1]](diffhunk://#diff-b7f4826da6ddd07dc96d71ec59f77e8a15dad3f56518ee96f51c0594017c864dL37-R39) [[2]](diffhunk://#diff-b7f4826da6ddd07dc96d71ec59f77e8a15dad3f56518ee96f51c0594017c864dL52-R53)

### Dispatch Logic Adjustments:
* Adjusted HTTP and WebSocket dispatch methods to account for the `excludeGlobalMiddlewares` parameter during middleware execution. (`src/Traits/Router/HandlesHttpDispatching.php`, `src/Traits/Router/HandlesWebSocketDispatching.php`) [[1]](diffhunk://#diff-f920cee5d9667fe655f68b1cadb7394488ae72a1dede031a8499056e64bc5108L57-R63) [[2]](diffhunk://#diff-f920cee5d9667fe655f68b1cadb7394488ae72a1dede031a8499056e64bc5108L74-R75) [[3]](diffhunk://#diff-dab66ccc1d6097453a8ba58b76ef799fda78e8101ccd9b0f8799251fd7ff258aL29-R29) [[4]](diffhunk://#diff-dab66ccc1d6097453a8ba58b76ef799fda78e8101ccd9b0f8799251fd7ff258aL42-R43)

### Unit Tests:
* Added comprehensive unit tests (`tests/Unit/ExcludeMiddlewareTest.php`) to verify:
  - Exclusion of global middlewares for WebSocket events and HTTP routes.
  - Correct execution of route-specific middlewares when global middlewares are excluded.
  - Handling of multiple exclusions and partial exclusions.