### PR TITLE
fix-upgrade-websocket-issue

### DIFF
--- a/src/Traits/Server/HandlesHttpWs.php
+++ b/src/Traits/Server/HandlesHttpWs.php
@@ -51,7 +51,8 @@ trait HandlesHttpWs
                 str_starts_with($data, 'OPTIONS ') || str_starts_with($data, 'PATCH ') ||
                 str_starts_with($data, 'HEAD ')
             ) {
-                if (str_contains($data, 'Upgrade: websocket')) {
+                if (stripos($data, 'Upgrade: websocket') !== false || 
+                    stripos($data, 'upgrade: websocket') !== false) {
                     $this->clientTypes[$clientId] = 'ws';
                     $this->logger->debug("[Sockeon Identification] WebSocket client identified: $clientId");
                 } else {


### PR DESCRIPTION
This pull request refines the WebSocket client identification logic in the `handleHttpWs` method to improve case-insensitivity handling for the `Upgrade: websocket` header.

### Improvements to WebSocket client identification:
* [`src/Traits/Server/HandlesHttpWs.php`](diffhunk://#diff-93d5ac6a35ad0b2be03a9147e7496fce781f161f60af6d21660745ffa635f5ffL54-R55): Updated the condition to use `stripos` for case-insensitive checks of both `Upgrade: websocket` and `upgrade: websocket`, ensuring consistent detection of WebSocket clients regardless of header casing.