### PR TITLE
Enhance API and configuration for Sockeon v3 upgrade

### DIFF
--- a/benchmark/fixtures/bench_server.php
+++ b/benchmark/fixtures/bench_server.php
@@ -103,7 +103,7 @@ final class BenchPresenceController extends SocketController
     public function onConnect(string $clientId): void
     {
         // ponytail: RedisNamespaceManager filters room members without client data store presence
-        $this->setClientData($clientId, 'bench', true);
+        $this->putData($clientId, 'bench', true);
     }
 }
 

--- a/bin/sockeon-upgrade
+++ b/bin/sockeon-upgrade
@@ -1,0 +1,152 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+use Sockeon\Sockeon\Upgrade\V2ToV3Upgrader;
+
+$autoloadPaths = [
+    __DIR__ . '/../vendor/autoload.php',
+    __DIR__ . '/../../../autoload.php',
+];
+
+foreach ($autoloadPaths as $autoload) {
+    if (is_file($autoload)) {
+        require $autoload;
+        break;
+    }
+}
+
+if (!class_exists(V2ToV3Upgrader::class)) {
+    fwrite(STDERR, "Could not load Sockeon autoloader. Run from a project with sockeon/sockeon installed.\n");
+    exit(1);
+}
+
+$options = getopt('', ['dry-run', 'config-only', 'code-only', 'help']);
+$args = array_values(array_filter(
+    $argv,
+    static fn (string $arg): bool => !str_starts_with($arg, '-') && $arg !== ($argv[0] ?? '')
+));
+
+if (isset($options['help'])) {
+    echo <<<HELP
+Sockeon v2 → v3 upgrade script
+
+Usage:
+  sockeon-upgrade [path] [--dry-run] [--config-only] [--code-only]
+
+Options:
+  --dry-run      Show what would change without writing files
+  --config-only  Only upgrade config files (engine, survivability, rate_limit caps)
+  --code-only    Only upgrade PHP API method calls
+  --help         Show this help
+
+Examples:
+  sockeon-upgrade .
+  sockeon-upgrade app/Controllers --dry-run
+  sockeon-upgrade config/sockeon.php
+
+See: https://sockeon.github.io/v3.0/getting-started/migration-v3.html
+
+HELP;
+    exit(0);
+}
+
+$path = $args[0] ?? getcwd();
+if ($path === false || (!is_dir($path) && !is_file($path))) {
+    fwrite(STDERR, "Path not found: {$path}\n");
+    exit(1);
+}
+
+$dryRun = isset($options['dry-run']);
+$upgrader = new V2ToV3Upgrader();
+$write = !$dryRun;
+$results = [];
+
+if (is_file($path)) {
+    $content = file_get_contents($path);
+    if ($content === false) {
+        fwrite(STDERR, "Could not read: {$path}\n");
+        exit(1);
+    }
+
+    if (isset($options['config-only'])) {
+        $result = $upgrader->upgradeConfig($content, $path);
+    } elseif (isset($options['code-only'])) {
+        $result = $upgrader->upgradePhp($content, $path);
+    } else {
+        $php = $upgrader->upgradePhp($content, $path);
+        $config = $upgrader->upgradeConfig($php['content'], $path);
+        $result = [
+            'content' => $config['content'],
+            'changes' => array_values(array_unique([...$php['changes'], ...$config['changes']])),
+        ];
+    }
+
+    if ($result['changes'] !== [] && $result['content'] !== $content) {
+        if ($write) {
+            file_put_contents($path, $result['content']);
+        }
+        $results[] = ['path' => $path, 'changed' => true, 'changes' => $result['changes']];
+    }
+} else {
+    $iterator = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($path, FilesystemIterator::SKIP_DOTS)
+    );
+
+    /** @var SplFileInfo $file */
+    foreach ($iterator as $file) {
+        if (!$file->isFile() || !str_ends_with($file->getPathname(), '.php')) {
+            continue;
+        }
+
+        $filePath = $file->getPathname();
+        if ($upgrader->shouldSkip($filePath)) {
+            continue;
+        }
+
+        $content = file_get_contents($filePath);
+        if ($content === false) {
+            continue;
+        }
+
+        if (isset($options['config-only'])) {
+            $result = $upgrader->upgradeConfig($content, $filePath);
+        } elseif (isset($options['code-only'])) {
+            $result = $upgrader->upgradePhp($content, $filePath);
+        } else {
+            $php = $upgrader->upgradePhp($content, $filePath);
+            $result = $upgrader->upgradeConfig($php['content'], $filePath);
+            $result['changes'] = array_values(array_unique([...$php['changes'], ...$result['changes']]));
+        }
+
+        if ($result['changes'] === [] || $result['content'] === $content) {
+            continue;
+        }
+
+        if ($write) {
+            file_put_contents($filePath, $result['content']);
+        }
+
+        $results[] = ['path' => $filePath, 'changed' => true, 'changes' => $result['changes']];
+    }
+}
+
+if ($results === []) {
+    echo "No changes needed.\n";
+    exit(0);
+}
+
+echo ($dryRun ? "Dry run — would update:\n" : "Updated:\n");
+foreach ($results as $result) {
+    echo "  {$result['path']}\n";
+    foreach ($result['changes'] as $change) {
+        echo "    - {$change}\n";
+    }
+}
+
+if ($dryRun) {
+    echo "\nRe-run without --dry-run to apply changes.\n";
+}
+
+exit(0);

--- a/composer.json
+++ b/composer.json
@@ -54,5 +54,8 @@
         "allow-plugins": {
             "pestphp/pest-plugin": true
         }
-    }
+    },
+    "bin": [
+        "bin/sockeon-upgrade"
+    ]
 }

--- a/src/Controllers/SocketController.php
+++ b/src/Controllers/SocketController.php
@@ -22,7 +22,6 @@ abstract class SocketController
 {
     /**
      * Instance of the server
-     * @var Server
      */
     private Server $server;
 
@@ -32,7 +31,6 @@ abstract class SocketController
      * This method is called by the server when registering the controller
      *
      * @param Server $server The server instance to set
-     * @return void
      */
     public function setServer(Server $server): void
     {
@@ -45,11 +43,21 @@ abstract class SocketController
      * @param string $clientId The ID of the client to send to
      * @param string $event The event name
      * @param array<string, mixed> $data The data to send
-     * @return void
      */
     public function emit(string $clientId, string $event, array $data): void
     {
-        $this->server->send($clientId, $event, $data);
+        $this->server->emit($clientId, $event, $data);
+    }
+
+    /**
+     * Sends a raw WebSocket payload to a specific client without event framing
+     *
+     * @param string $clientId The ID of the client to send to
+     * @param string $payload Raw message data
+     */
+    public function sendRaw(string $clientId, string $payload): void
+    {
+        $this->server->sendRaw($clientId, $payload);
     }
 
     /**
@@ -59,7 +67,6 @@ abstract class SocketController
      * @param array<string, mixed> $data The data to send
      * @param string|null $namespace Optional namespace to broadcast within
      * @param string|null $room Optional room to broadcast to
-     * @return void
      */
     public function broadcast(string $event, array $data, ?string $namespace = null, ?string $room = null): void
     {
@@ -67,36 +74,79 @@ abstract class SocketController
     }
 
     /**
-     * Broadcasts an event to specified clients
+     * Broadcasts an event to the given client IDs
      *
-     * @param list<string> $clients The array of the client ids to broadcast
      * @param string $event The event name
      * @param array<string, mixed> $data The data to send
-     * @return void
+     * @param list<string> $clientIds Client IDs to send to
      */
-    public function broadcastTo(array $clients, string $event, array $data): void
+    public function broadcastTo(string $event, array $data, array $clientIds): void
     {
-        foreach ($clients as $client) {
-            $this->emit($client, $event, $data);
+        foreach ($clientIds as $clientId) {
+            $this->emit($clientId, $event, $data);
         }
     }
 
     /**
-     * Broadcasts an event to all clients except the given ones
+     * Broadcasts an event to all connected clients except the given ones
      *
-     * @param list<string> $excepts The array of the client ids to ignore
      * @param string $event The event name
      * @param array<string, mixed> $data The data to send
-     * @return void
+     * @param list<string> $exceptClientIds Client IDs to exclude
      */
-    public function broadcastExcept(array $excepts, string $event, array $data): void
+    public function broadcastExcept(string $event, array $data, array $exceptClientIds): void
     {
-        $clients = $this->getAllClients();
-        foreach ($clients as $client) {
-            if (!in_array($client, $excepts)) {
-                $this->emit($client, $event, $data);
+        foreach ($this->getClientIds() as $clientId) {
+            if (!in_array($clientId, $exceptClientIds, true)) {
+                $this->emit($clientId, $event, $data);
             }
         }
+    }
+
+    /**
+     * Broadcasts an event to all clients in a specific namespace
+     *
+     * @param string $event The event name
+     * @param array<string, mixed> $data The data to send
+     * @param string $namespace The namespace to broadcast to
+     */
+    public function broadcastToNamespace(string $event, array $data, string $namespace): void
+    {
+        $this->server->broadcast($event, $data, $namespace);
+    }
+
+    /**
+     * Broadcasts an event to all clients in a specific room
+     *
+     * @param string $event The event name
+     * @param array<string, mixed> $data The data to send
+     * @param string $namespace The namespace containing the room
+     * @param string $room The room to broadcast to
+     */
+    public function broadcastToRoom(string $event, array $data, string $namespace, string $room): void
+    {
+        $this->server->broadcast($event, $data, $namespace, $room);
+    }
+
+    /**
+     * Joins a client to a namespace
+     *
+     * @param string $clientId The client ID to move
+     * @param string $namespace The namespace to join
+     */
+    public function joinNamespace(string $clientId, string $namespace = '/'): void
+    {
+        $this->server->getNamespaceManager()->joinNamespace($clientId, $namespace);
+    }
+
+    /**
+     * Removes a client from their current namespace
+     *
+     * @param string $clientId The client ID to remove
+     */
+    public function leaveNamespace(string $clientId): void
+    {
+        $this->server->getNamespaceManager()->leaveNamespace($clientId);
     }
 
     /**
@@ -104,8 +154,7 @@ abstract class SocketController
      *
      * @param string $clientId The ID of the client to add
      * @param string $room The room name
-     * @param string $namespace The namespace
-     * @return void
+     * @param string $namespace The namespace containing the room
      */
     public function joinRoom(string $clientId, string $room, string $namespace = '/'): void
     {
@@ -118,11 +167,20 @@ abstract class SocketController
      * @param string $clientId The ID of the client to remove
      * @param string $room The room name to leave
      * @param string $namespace The namespace containing the room
-     * @return void
      */
     public function leaveRoom(string $clientId, string $room, string $namespace = '/'): void
     {
         $this->server->leaveRoom($clientId, $room, $namespace);
+    }
+
+    /**
+     * Removes a client from all rooms they belong to
+     *
+     * @param string $clientId The client ID to remove from all rooms
+     */
+    public function leaveAllRooms(string $clientId): void
+    {
+        $this->server->getNamespaceManager()->leaveAllRooms($clientId);
     }
 
     /**
@@ -131,36 +189,73 @@ abstract class SocketController
      * Closes the connection and cleans up all client resources
      *
      * @param string $clientId The ID of the client to disconnect
-     * @return void
      */
-    public function disconnectClient(string $clientId): void
+    public function disconnect(string $clientId): void
     {
         $this->server->disconnectClient($clientId);
     }
 
     /**
-     * Gets data for a specific client
+     * Gets all arbitrary data attached to a client connection
      *
-     * @param string $clientId The ID of the client to get data for
-     * @param string|null $key Optional key to retrieve specific data
-     * @return mixed The data for the client, or null if not found
+     * @param string $clientId The client ID
+     * @return array<string, mixed>|null All stored data, or null if none
      */
-    public function getClientData(string $clientId, ?string $key = null): mixed
+    public function allData(string $clientId): ?array
+    {
+        $data = $this->server->getClientData($clientId);
+
+        return is_array($data) ? $data : null;
+    }
+
+    /**
+     * Gets a single value from a client's attached data
+     *
+     * @param string $clientId The client ID
+     * @param string $key The data key to retrieve
+     * @return mixed The stored value, or null if not found
+     */
+    public function data(string $clientId, string $key): mixed
     {
         return $this->server->getClientData($clientId, $key);
     }
 
     /**
-     * Sets data for a specific client
+     * Stores a value in a client's attached data
      *
-     * @param string $clientId The ID of the client to set data for
-     * @param string $key The key to set in the client's data
-     * @param mixed $value The value to set for the key
-     * @return void
+     * @param string $clientId The client ID
+     * @param string $key The data key to set
+     * @param mixed $value The value to store
      */
-    public function setClientData(string $clientId, string $key, mixed $value): void
+    public function putData(string $clientId, string $key, mixed $value): void
     {
         $this->server->setClientData($clientId, $key, $value);
+    }
+
+    /**
+     * Checks whether a client has a specific data key
+     *
+     * @param string $clientId The client ID
+     * @param string $key The data key to check
+     */
+    public function hasData(string $clientId, string $key): bool
+    {
+        $stored = $this->server->getClientData($clientId);
+
+        return is_array($stored) && array_key_exists($key, $stored);
+    }
+
+    /**
+     * Removes data from a client connection
+     *
+     * When $key is null, all data for the client is removed.
+     *
+     * @param string $clientId The client ID
+     * @param string|null $key Optional key to remove; omit to clear all data
+     */
+    public function forgetData(string $clientId, ?string $key = null): void
+    {
+        $this->server->forgetClientData($clientId, $key);
     }
 
     /**
@@ -183,18 +278,6 @@ abstract class SocketController
     public function getClientNamespace(string $clientId): string
     {
         return $this->server->getNamespaceManager()->getClientNamespace($clientId);
-    }
-
-    /**
-     * Joins a client to a specific namespace
-     *
-     * @param string $clientId The client ID to move
-     * @param string $namespace The namespace to join
-     * @return void
-     */
-    public function moveClientToNamespace(string $clientId, string $namespace = '/'): void
-    {
-        $this->server->getNamespaceManager()->joinNamespace($clientId, $namespace);
     }
 
     /**
@@ -232,61 +315,11 @@ abstract class SocketController
     }
 
     /**
-     * Removes a client from all rooms they belong to
-     *
-     * @param string $clientId The client ID to remove from all rooms
-     * @return void
-     */
-    public function leaveAllRooms(string $clientId): void
-    {
-        $this->server->getNamespaceManager()->leaveAllRooms($clientId);
-    }
-
-    /**
-     * Broadcasts an event to all clients in a specific namespace
-     *
-     * @param string $event The event name
-     * @param array<string, mixed> $data The data to send
-     * @param string $namespace The namespace to broadcast to
-     * @return void
-     */
-    public function broadcastToNamespaceClients(string $event, array $data, string $namespace): void
-    {
-        $this->server->broadcast($event, $data, $namespace);
-    }
-
-    /**
-     * Broadcasts an event to all clients in a specific room
-     *
-     * @param string $event The event name
-     * @param array<string, mixed> $data The data to send
-     * @param string $room The room to broadcast to
-     * @param string $namespace The namespace containing the room (default: '/')
-     * @return void
-     */
-    public function broadcastToRoomClients(string $event, array $data, string $room, string $namespace = '/'): void
-    {
-        $this->server->broadcast($event, $data, $namespace, $room);
-    }
-
-    /**
-     * Broadcasts an event to all connected clients
-     *
-     * @param string $event The event name
-     * @param array<string, mixed> $data The data to send
-     * @return void
-     */
-    public function broadcastToAll(string $event, array $data): void
-    {
-        $this->server->broadcast($event, $data);
-    }
-
-    /**
      * Gets all connected client IDs
      *
      * @return list<string> Array of all connected client IDs
      */
-    public function getAllClients(): array
+    public function getClientIds(): array
     {
         return $this->server->getClientIds();
     }
@@ -307,7 +340,7 @@ abstract class SocketController
      * @param string $clientId The client ID to check
      * @return bool True if the client is connected, false otherwise
      */
-    public function isClientConnected(string $clientId): bool
+    public function isConnected(string $clientId): bool
     {
         return $this->server->isClientConnected($clientId);
     }
@@ -321,6 +354,17 @@ abstract class SocketController
     public function getClientType(string $clientId): ?string
     {
         return $this->server->getClientType($clientId);
+    }
+
+    /**
+     * Gets the IP address of a client
+     *
+     * @param string $clientId The client ID
+     * @return string|null The client IP address or null if not found
+     */
+    public function getClientIp(string $clientId): ?string
+    {
+        return $this->server->getClientIpAddress($clientId);
     }
 
     /**
@@ -412,7 +456,6 @@ abstract class SocketController
      * @param string $type Task type
      * @param array<string, mixed> $data Task data
      * @param int $priority Priority level (higher = more important)
-     * @return void
      */
     public function queueAsyncTask(string $type, array $data, int $priority = 0): void
     {
@@ -468,22 +511,10 @@ abstract class SocketController
     }
 
     /**
-     * Get client IP address
-     *
-     * @param string $clientId The client ID
-     * @return string|null The client IP address or null if not found
-     */
-    public function getClientIpAddress(string $clientId): ?string
-    {
-        return $this->server->getClientIpAddress($clientId);
-    }
-
-    /**
      * Record a performance metric
      *
      * @param string $type Metric type (http/websocket/connection/request)
      * @param float $value Metric value (response time, etc.)
-     * @return void
      */
     public function recordMetric(string $type, float $value = 0): void
     {
@@ -494,7 +525,6 @@ abstract class SocketController
      * Record an error metric
      *
      * @param string $type Error type (connection/request)
-     * @return void
      */
     public function recordError(string $type): void
     {

--- a/src/Core/RedisClientDataStore.php
+++ b/src/Core/RedisClientDataStore.php
@@ -56,6 +56,17 @@ class RedisClientDataStore
         $this->redis->del($this->key($clientId));
     }
 
+    public function forget(string $clientId, ?string $key = null): void
+    {
+        if ($key === null) {
+            $this->delete($clientId);
+
+            return;
+        }
+
+        $this->redis->hDel($this->key($clientId), $key);
+    }
+
     private function key(string $clientId): string
     {
         return $this->config->getRedisPrefix() . 'client:' . $clientId . ':data';

--- a/src/Traits/Server/HandlesClients.php
+++ b/src/Traits/Server/HandlesClients.php
@@ -509,6 +509,26 @@ trait HandlesClients
         return $this->clientData[$clientId][$key] ?? null;
     }
 
+    public function forgetClientData(string $clientId, ?string $key = null): void
+    {
+        if ($this->redisClientDataStore !== null) {
+            $this->redisClientDataStore->forget($clientId, $key);
+
+            return;
+        }
+
+        if ($key === null) {
+            $this->clearClientData($clientId);
+
+            return;
+        }
+
+        unset($this->clientData[$clientId][$key]);
+        if (($this->clientData[$clientId] ?? []) === []) {
+            unset($this->clientData[$clientId]);
+        }
+    }
+
     protected function clearClientData(string $clientId): void
     {
         unset($this->clientData[$clientId]);

--- a/src/Traits/Server/HandlesQueue.php
+++ b/src/Traits/Server/HandlesQueue.php
@@ -81,7 +81,7 @@ trait HandlesQueue
         $data = is_array($payload['data'] ?? null) ? $payload['data'] : [];
 
         if ($clientId !== '' && $event !== '') {
-            $this->send($clientId, $event, $data);
+            $this->emit($clientId, $event, $data);
         } else {
             $this->logger->warning("[Queue] Invalid emit payload");
         }

--- a/src/Traits/Server/HandlesSendBroadcast.php
+++ b/src/Traits/Server/HandlesSendBroadcast.php
@@ -14,7 +14,7 @@ trait HandlesSendBroadcast
      * @param array<string, mixed> $data Data to send
      * @return void
      */
-    public function send(string $clientId, string $event, array $data): void
+    public function emit(string $clientId, string $event, array $data): void
     {
         if (!$this->isWebSocketClient($clientId)) {
             return;
@@ -37,7 +37,7 @@ trait HandlesSendBroadcast
      * @param string $message Raw message data
      * @return void
      */
-    public function sendToClient(string $clientId, string $message): void
+    public function sendRaw(string $clientId, string $message): void
     {
         if (!$this->isWebSocketClient($clientId)) {
             return;

--- a/src/Upgrade/CallArgumentParser.php
+++ b/src/Upgrade/CallArgumentParser.php
@@ -64,6 +64,7 @@ final class CallArgumentParser
     }
 
     /**
+     * @param list<string> $args
      * @param list<int> $order Indexes into $args to emit
      */
     public static function join(array $args, array $order): string

--- a/src/Upgrade/CallArgumentParser.php
+++ b/src/Upgrade/CallArgumentParser.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Sockeon\Sockeon\Upgrade;
+
+/**
+ * ponytail: naive comma-split at depth 0; good enough for upgrade codemods on method calls.
+ */
+final class CallArgumentParser
+{
+    /**
+     * @return list<string>
+     */
+    public static function split(string $arguments): array
+    {
+        $args = [];
+        $current = '';
+        $depth = 0;
+        $length = strlen($arguments);
+
+        for ($i = 0; $i < $length; $i++) {
+            $char = $arguments[$i];
+            $prev = $i > 0 ? $arguments[$i - 1] : '';
+
+            if ($char === '(' || $char === '[' || $char === '{') {
+                $depth++;
+                $current .= $char;
+                continue;
+            }
+
+            if ($char === ')' || $char === ']' || $char === '}') {
+                $depth--;
+                $current .= $char;
+                continue;
+            }
+
+            if ($char === ',' && $depth === 0) {
+                $args[] = trim($current);
+                $current = '';
+                continue;
+            }
+
+            if (($char === '"' || $char === "'") && $prev !== '\\') {
+                $quote = $char;
+                $current .= $char;
+                $i++;
+                while ($i < $length) {
+                    $current .= $arguments[$i];
+                    if ($arguments[$i] === $quote && $arguments[$i - 1] !== '\\') {
+                        break;
+                    }
+                    $i++;
+                }
+                continue;
+            }
+
+            $current .= $char;
+        }
+
+        if (trim($current) !== '') {
+            $args[] = trim($current);
+        }
+
+        return $args;
+    }
+
+    /**
+     * @param list<int> $order Indexes into $args to emit
+     */
+    public static function join(array $args, array $order): string
+    {
+        $parts = [];
+        foreach ($order as $index) {
+            if (!array_key_exists($index, $args)) {
+                return implode(', ', $args);
+            }
+            $parts[] = $args[$index];
+        }
+
+        return implode(', ', $parts);
+    }
+}

--- a/src/Upgrade/V2ToV3Upgrader.php
+++ b/src/Upgrade/V2ToV3Upgrader.php
@@ -1,0 +1,342 @@
+<?php
+
+namespace Sockeon\Sockeon\Upgrade;
+
+final class V2ToV3Upgrader
+{
+    /**
+     * @var list<string>
+     */
+    private array $changes = [];
+
+    /**
+     * @return array{content: string, changes: list<string>}
+     */
+    public function upgradePhp(string $content, string $path = ''): array
+    {
+        $this->changes = [];
+        $original = $content;
+
+        $content = $this->protectEngineSendCalls($content);
+        $content = $this->applyLiteralRenames($content);
+        $content = $this->restoreEngineSendCalls($content);
+        $content = $this->reorderMethodArguments($content, 'broadcastTo', [1, 2, 0]);
+        $content = $this->reorderMethodArguments($content, 'broadcastExcept', [1, 2, 0]);
+        $content = $this->reorderMethodArguments($content, 'broadcastToRoom', [0, 1, 3, 2]);
+        $content = $this->rewriteControllerGetClientDataCalls($content);
+
+        if ($content !== $original) {
+            $this->changes[] = $path !== '' ? "Updated API calls in {$path}" : 'Updated API calls';
+        }
+
+        return ['content' => $content, 'changes' => $this->changes];
+    }
+
+    /**
+     * @return array{content: string, changes: list<string>}
+     */
+    public function upgradeConfig(string $content, string $path = ''): array
+    {
+        $this->changes = [];
+        $original = $content;
+
+        if (!$this->looksLikeSockeonConfig($content)) {
+            return ['content' => $content, 'changes' => []];
+        }
+
+        if (!str_contains($content, "'survivability'") && !str_contains($content, '"survivability"')) {
+            $content = $this->insertAfterDebugLine($content, <<<'PHP'
+
+    'engine' => 'stream_select',
+    'survivability' => [
+        'max_connections' => 10_000,
+    ],
+PHP
+            );
+            $this->changes[] = $path !== '' ? "Added engine/survivability to {$path}" : 'Added engine/survivability config';
+        }
+
+        if (
+            (str_contains($content, "'rate_limit'") || str_contains($content, '"rate_limit"'))
+            && !str_contains($content, 'maxGlobalConnections')
+        ) {
+            $content = $this->appendRateLimitConnectionCaps($content);
+            $this->changes[] = $path !== '' ? "Added connection caps to rate_limit in {$path}" : 'Added rate_limit connection caps';
+        }
+
+        if ($content === $original && $this->changes === []) {
+            return ['content' => $content, 'changes' => []];
+        }
+
+        return ['content' => $content, 'changes' => $this->changes];
+    }
+
+    /**
+     * @return array{changed: bool, changes: list<string>}
+     */
+    public function upgradeFile(string $path, bool $write): array
+    {
+        if (!is_file($path)) {
+            return ['changed' => false, 'changes' => ["Skip missing file: {$path}"]];
+        }
+
+        $content = file_get_contents($path);
+        if ($content === false) {
+            return ['changed' => false, 'changes' => ["Could not read: {$path}"]];
+        }
+
+        $result = $this->upgradePhp($content, $path);
+        $config = $this->upgradeConfig($result['content'], $path);
+        $mergedChanges = array_values(array_unique([...$result['changes'], ...$config['changes']]));
+
+        if ($mergedChanges === [] || $config['content'] === $content) {
+            return ['changed' => false, 'changes' => []];
+        }
+
+        if ($write) {
+            file_put_contents($path, $config['content']);
+        }
+
+        return ['changed' => true, 'changes' => $mergedChanges];
+    }
+
+    /**
+     * @return list<array{path: string, changed: bool, changes: list<string>}>
+     */
+    public function upgradeDirectory(string $directory, bool $write): array
+    {
+        $results = [];
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($directory, \FilesystemIterator::SKIP_DOTS)
+        );
+
+        /** @var \SplFileInfo $file */
+        foreach ($iterator as $file) {
+            if (!$file->isFile() || !str_ends_with($file->getPathname(), '.php')) {
+                continue;
+            }
+
+            $path = $file->getPathname();
+            if ($this->shouldSkipPath($path)) {
+                continue;
+            }
+
+            $outcome = $this->upgradeFile($path, $write);
+            if ($outcome['changed']) {
+                $results[] = [
+                    'path' => $path,
+                    'changed' => true,
+                    'changes' => $outcome['changes'],
+                ];
+            }
+        }
+
+        return $results;
+    }
+
+    private function looksLikeSockeonConfig(string $content): bool
+    {
+        return str_contains($content, 'ServerConfig')
+            || (str_contains($content, "'host'") && str_contains($content, "'port'"));
+    }
+
+    private function shouldSkipPath(string $path): bool
+    {
+        foreach (['/vendor/', '/.git/', '/node_modules/', '/storage/', '/cache/', '/src/Upgrade/', 'V2ToV3UpgraderTest.php'] as $segment) {
+            if (str_contains($path, $segment)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function shouldSkip(string $path): bool
+    {
+        return $this->shouldSkipPath($path);
+    }
+
+    private function insertAfterDebugLine(string $content, string $snippet): string
+    {
+        if (preg_match("/^(\s*)'debug'\s*=>[^\n]*\n/m", $content, $matches, PREG_OFFSET_CAPTURE)) {
+            $insertAt = $matches[0][1] + strlen($matches[0][0]);
+
+            return substr($content, 0, $insertAt) . $snippet . "\n" . substr($content, $insertAt);
+        }
+
+        if (preg_match('/return\s*\[/', $content, $matches, PREG_OFFSET_CAPTURE)) {
+            $insertAt = $matches[0][1] + strlen($matches[0][0]);
+
+            return substr($content, 0, $insertAt) . $snippet . "\n" . substr($content, $insertAt);
+        }
+
+        return $content;
+    }
+
+    private function appendRateLimitConnectionCaps(string $content): string
+    {
+        return (string) preg_replace_callback(
+            "/(['\"]rate_limit['\"]\s*=>\s*\[)([^\]]*)\]/s",
+            static function (array $matches): string {
+                $inner = $matches[2];
+                if (str_contains($inner, 'maxGlobalConnections')) {
+                    return $matches[0];
+                }
+
+                $padding = "\n        'maxGlobalConnections' => 10_000,\n        'maxConnectionsPerIp' => 100,";
+
+                return $matches[1] . $inner . $padding . "\n    ]";
+            },
+            $content,
+            1
+        );
+    }
+
+    private function applyLiteralRenames(string $content): string
+    {
+        $map = [
+            '/\$server->send\(/' => '$server->emit(',
+            '/\$this->getServer\(\)->send\(/' => '$this->getServer()->emit(',
+            '/\$server->sendToClient\(/' => '$server->sendRaw(',
+            '/\$this->getServer\(\)->sendToClient\(/' => '$this->getServer()->sendRaw(',
+            '/\$this->sendToClient\(/' => '$this->sendRaw(',
+            '/->broadcastToRoomClients\(/' => '->broadcastToRoom(',
+            '/->broadcastToNamespaceClients\(/' => '->broadcastToNamespace(',
+            '/->moveClientToNamespace\(/' => '->joinNamespace(',
+            '/->getAllClients\(/' => '->getClientIds(',
+            '/->broadcastToAll\(/' => '->broadcast(',
+            '/\$this->disconnectClient\(/' => '$this->disconnect(',
+            '/\$this->isClientConnected\(/' => '$this->isConnected(',
+            '/\$this->getClientIpAddress\(/' => '$this->getClientIp(',
+            '/\$this->setClientData\(/' => '$this->putData(',
+            '/\$this->hasClientData\(/' => '$this->hasData(',
+        ];
+
+        foreach ($map as $pattern => $replacement) {
+            $content = (string) preg_replace($pattern, $replacement, $content);
+        }
+
+        return $content;
+    }
+
+    private string $engineSendPlaceholder = '';
+
+    private function protectEngineSendCalls(string $content): string
+    {
+        $this->engineSendPlaceholder = '__SOCKEON_ENGINE_SEND_' . bin2hex(random_bytes(4)) . '__';
+
+        return (string) preg_replace(
+            '/getEngine\(\)->send\(/',
+            $this->engineSendPlaceholder . '(',
+            $content
+        );
+    }
+
+    private function restoreEngineSendCalls(string $content): string
+    {
+        if ($this->engineSendPlaceholder === '') {
+            return $content;
+        }
+
+        return str_replace($this->engineSendPlaceholder . '(', 'getEngine()->send(', $content);
+    }
+
+    /**
+     * @param list<int> $order
+     */
+    private function reorderMethodArguments(string $content, string $method, array $order): string
+    {
+        $search = '->' . $method . '(';
+        $offset = 0;
+
+        while (($pos = strpos($content, $search, $offset)) !== false) {
+            $openParen = $pos + strlen($search) - 1;
+            $closeParen = $this->findClosingParen($content, $openParen);
+            if ($closeParen === null) {
+                $offset = $pos + 1;
+                continue;
+            }
+
+            $argsStart = $openParen + 1;
+            $argsString = substr($content, $argsStart, $closeParen - $argsStart);
+            $args = CallArgumentParser::split($argsString);
+            if (count($args) < count($order)) {
+                $offset = $pos + 1;
+                continue;
+            }
+
+            $newArgs = CallArgumentParser::join($args, $order);
+            $content = substr($content, 0, $argsStart) . $newArgs . substr($content, $closeParen);
+            $offset = $argsStart + strlen($newArgs) + 1;
+        }
+
+        return $content;
+    }
+
+    private function rewriteControllerGetClientDataCalls(string $content): string
+    {
+        $search = '$this->getClientData(';
+        $offset = 0;
+
+        while (($pos = strpos($content, $search, $offset)) !== false) {
+            $openParen = $pos + strlen($search) - 1;
+            $closeParen = $this->findClosingParen($content, $openParen);
+            if ($closeParen === null) {
+                $offset = $pos + 1;
+                continue;
+            }
+
+            $argsStart = $openParen + 1;
+            $argsString = substr($content, $argsStart, $closeParen - $argsStart);
+            $args = CallArgumentParser::split($argsString);
+
+            $replacement = match (count($args)) {
+                1 => '$this->allData(' . $args[0] . ')',
+                2 => '$this->data(' . implode(', ', $args) . ')',
+                default => '$this->getClientData(' . $argsString . ')',
+            };
+
+            $content = substr($content, 0, $pos) . $replacement . substr($content, $closeParen + 1);
+            $offset = $pos + strlen($replacement);
+        }
+
+        return $content;
+    }
+
+    private function findClosingParen(string $content, int $openParen): ?int
+    {
+        $depth = 0;
+        $length = strlen($content);
+
+        for ($i = $openParen; $i < $length; $i++) {
+            $char = $content[$i];
+            $prev = $i > 0 ? $content[$i - 1] : '';
+
+            if (($char === '"' || $char === "'") && $prev !== '\\') {
+                $quote = $char;
+                $i++;
+                while ($i < $length) {
+                    if ($content[$i] === $quote && $content[$i - 1] !== '\\') {
+                        break;
+                    }
+                    $i++;
+                }
+                continue;
+            }
+
+            if ($char === '(') {
+                $depth++;
+                continue;
+            }
+
+            if ($char === ')') {
+                $depth--;
+                if ($depth === 0) {
+                    return $i;
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Upgrade/V2ToV3Upgrader.php
+++ b/src/Upgrade/V2ToV3Upgrader.php
@@ -45,13 +45,15 @@ final class V2ToV3Upgrader
         }
 
         if (!str_contains($content, "'survivability'") && !str_contains($content, '"survivability"')) {
-            $content = $this->insertAfterDebugLine($content, <<<'PHP'
+            $content = $this->insertAfterDebugLine(
+                $content,
+                <<<'PHP'
 
-    'engine' => 'stream_select',
-    'survivability' => [
-        'max_connections' => 10_000,
-    ],
-PHP
+                        'engine' => 'stream_select',
+                        'survivability' => [
+                            'max_connections' => 10_000,
+                        ],
+                    PHP
             );
             $this->changes[] = $path !== '' ? "Added engine/survivability to {$path}" : 'Added engine/survivability config';
         }

--- a/src/WebSocket/Middleware/WebSocketRateLimitMiddleware.php
+++ b/src/WebSocket/Middleware/WebSocketRateLimitMiddleware.php
@@ -266,7 +266,7 @@ class WebSocketRateLimitMiddleware implements WebsocketMiddleware
 
         $jsonMessage = json_encode($message);
         if ($jsonMessage !== false) {
-            $server->sendToClient($clientId, $jsonMessage);
+            $server->sendRaw($clientId, $jsonMessage);
         }
     }
 
@@ -296,7 +296,7 @@ class WebSocketRateLimitMiddleware implements WebsocketMiddleware
 
         $jsonMessage = json_encode($message);
         if ($jsonMessage !== false) {
-            $server->sendToClient($clientId, $jsonMessage);
+            $server->sendRaw($clientId, $jsonMessage);
         }
     }
 

--- a/tests/Feature/RoomTest.php
+++ b/tests/Feature/RoomTest.php
@@ -51,7 +51,7 @@ test('messages can be broadcast to rooms', function () {
          * @return bool
          */
         #[SocketOn('broadcast.room')]
-        public function broadcastToRoom(string $clientId, array $data): bool
+        public function onBroadcastToRoom(string $clientId, array $data): bool
         {
             $this->broadcast('room.message', [
                 'message' => $data['message'] ?? '',
@@ -77,7 +77,7 @@ test('namespaces can be created and managed', function () {
          * @return bool
          */
         #[SocketOn('namespace.join')]
-        public function joinNamespace(string $clientId, array $data): bool
+        public function onJoinNamespace(string $clientId, array $data): bool
         {
             $this->joinRoom($clientId, 'room1', $data['namespace'] ?? '/');
             return true;
@@ -89,7 +89,7 @@ test('namespaces can be created and managed', function () {
          * @return bool
          */
         #[SocketOn('namespace.broadcast')]
-        public function broadcastToNamespace(string $clientId, array $data): bool
+        public function onBroadcastToNamespace(string $clientId, array $data): bool
         {
             $this->broadcast('message', [
                 'data' => $data['message'] ?? '',
@@ -153,7 +153,7 @@ test('rooms in different namespaces are isolated', function () {
          * @return bool
          */
         #[SocketOn('room.broadcast')]
-        public function broadcastToRoom(string $clientId, array $data): bool
+        public function onRoomBroadcast(string $clientId, array $data): bool
         {
             $this->broadcast('message', [
                 'data' => $data['message'] ?? '',

--- a/tests/Unit/V2ToV3UpgraderTest.php
+++ b/tests/Unit/V2ToV3UpgraderTest.php
@@ -4,35 +4,35 @@ use Sockeon\Sockeon\Upgrade\V2ToV3Upgrader;
 
 test('upgrades server and controller API calls', function () {
     $source = <<<'PHP'
-<?php
+        <?php
 
-class ChatController extends SocketController
-{
-    public function handle(string $clientId, array $data): void
-    {
-        $server = $this->getServer();
-        $server->send($clientId, 'chat.message', $data);
-        $server->sendToClient($clientId, 'raw');
+        class ChatController extends SocketController
+        {
+            public function handle(string $clientId, array $data): void
+            {
+                $server = $this->getServer();
+                $server->send($clientId, 'chat.message', $data);
+                $server->sendToClient($clientId, 'raw');
 
-        $this->broadcastToRoomClients('chat.message', $data, $data['room'], '/chat');
-        $this->broadcastToNamespaceClients('announcement', $data, '/admin');
-        $this->broadcastToAll('ping', []);
-        $this->broadcastTo([$clientId], 'direct', $data);
-        $this->broadcastExcept([$clientId], 'others', $data);
-        $this->moveClientToNamespace($clientId, '/chat');
-        $this->getAllClients();
-        $this->disconnectClient($clientId);
-        $this->isClientConnected($clientId);
-        $this->getClientIpAddress($clientId);
-        $this->setClientData($clientId, 'name', 'Ada');
-        $name = $this->getClientData($clientId, 'name');
-        $bag = $this->getClientData($clientId);
-        $this->hasClientData($clientId, 'name');
+                $this->broadcastToRoomClients('chat.message', $data, $data['room'], '/chat');
+                $this->broadcastToNamespaceClients('announcement', $data, '/admin');
+                $this->broadcastToAll('ping', []);
+                $this->broadcastTo([$clientId], 'direct', $data);
+                $this->broadcastExcept([$clientId], 'others', $data);
+                $this->moveClientToNamespace($clientId, '/chat');
+                $this->getAllClients();
+                $this->disconnectClient($clientId);
+                $this->isClientConnected($clientId);
+                $this->getClientIpAddress($clientId);
+                $this->setClientData($clientId, 'name', 'Ada');
+                $name = $this->getClientData($clientId, 'name');
+                $bag = $this->getClientData($clientId);
+                $this->hasClientData($clientId, 'name');
 
-        $this->getServer()->getEngine()->send($clientId, 'payload');
-    }
-}
-PHP;
+                $this->getServer()->getEngine()->send($clientId, 'payload');
+            }
+        }
+        PHP;
 
     $upgrader = new V2ToV3Upgrader();
     $result = $upgrader->upgradePhp($source);
@@ -59,18 +59,18 @@ PHP;
 
 test('upgrades sockeon config defaults', function () {
     $source = <<<'PHP'
-<?php
+        <?php
 
-return [
-    'host' => '0.0.0.0',
-    'port' => 6001,
-    'debug' => false,
-    'rate_limit' => [
-        'enabled' => true,
-        'maxHttpRequestsPerIp' => 100,
-    ],
-];
-PHP;
+        return [
+            'host' => '0.0.0.0',
+            'port' => 6001,
+            'debug' => false,
+            'rate_limit' => [
+                'enabled' => true,
+                'maxHttpRequestsPerIp' => 100,
+            ],
+        ];
+        PHP;
 
     $upgrader = new V2ToV3Upgrader();
     $result = $upgrader->upgradeConfig($source, 'config/sockeon.php');

--- a/tests/Unit/V2ToV3UpgraderTest.php
+++ b/tests/Unit/V2ToV3UpgraderTest.php
@@ -1,0 +1,89 @@
+<?php
+
+use Sockeon\Sockeon\Upgrade\V2ToV3Upgrader;
+
+test('upgrades server and controller API calls', function () {
+    $source = <<<'PHP'
+<?php
+
+class ChatController extends SocketController
+{
+    public function handle(string $clientId, array $data): void
+    {
+        $server = $this->getServer();
+        $server->send($clientId, 'chat.message', $data);
+        $server->sendToClient($clientId, 'raw');
+
+        $this->broadcastToRoomClients('chat.message', $data, $data['room'], '/chat');
+        $this->broadcastToNamespaceClients('announcement', $data, '/admin');
+        $this->broadcastToAll('ping', []);
+        $this->broadcastTo([$clientId], 'direct', $data);
+        $this->broadcastExcept([$clientId], 'others', $data);
+        $this->moveClientToNamespace($clientId, '/chat');
+        $this->getAllClients();
+        $this->disconnectClient($clientId);
+        $this->isClientConnected($clientId);
+        $this->getClientIpAddress($clientId);
+        $this->setClientData($clientId, 'name', 'Ada');
+        $name = $this->getClientData($clientId, 'name');
+        $bag = $this->getClientData($clientId);
+        $this->hasClientData($clientId, 'name');
+
+        $this->getServer()->getEngine()->send($clientId, 'payload');
+    }
+}
+PHP;
+
+    $upgrader = new V2ToV3Upgrader();
+    $result = $upgrader->upgradePhp($source);
+
+    expect($result['content'])
+        ->toContain('$server->emit(')
+        ->toContain('$server->sendRaw(')
+        ->toContain("->broadcastToRoom('chat.message', \$data, '/chat', \$data['room'])")
+        ->toContain("->broadcastToNamespace('announcement', \$data, '/admin')")
+        ->toContain("->broadcast('ping', [])")
+        ->toContain("->broadcastTo('direct', \$data, [\$clientId])")
+        ->toContain("->broadcastExcept('others', \$data, [\$clientId])")
+        ->toContain("->joinNamespace(\$clientId, '/chat')")
+        ->toContain('->getClientIds()')
+        ->toContain('$this->disconnect(')
+        ->toContain('$this->isConnected(')
+        ->toContain('$this->getClientIp(')
+        ->toContain('$this->putData(')
+        ->toContain("\$this->data(\$clientId, 'name')")
+        ->toContain('$this->allData($clientId)')
+        ->toContain('$this->hasData(')
+        ->toContain("getEngine()->send(\$clientId, 'payload')");
+});
+
+test('upgrades sockeon config defaults', function () {
+    $source = <<<'PHP'
+<?php
+
+return [
+    'host' => '0.0.0.0',
+    'port' => 6001,
+    'debug' => false,
+    'rate_limit' => [
+        'enabled' => true,
+        'maxHttpRequestsPerIp' => 100,
+    ],
+];
+PHP;
+
+    $upgrader = new V2ToV3Upgrader();
+    $result = $upgrader->upgradeConfig($source, 'config/sockeon.php');
+
+    expect($result['content'])
+        ->toContain("'engine' => 'stream_select'")
+        ->toContain("'survivability'")
+        ->toContain('maxGlobalConnections')
+        ->toContain('maxConnectionsPerIp');
+});
+
+test('call argument parser splits nested arrays', function () {
+    $args = Sockeon\Sockeon\Upgrade\CallArgumentParser::split("['a'], 'event', ['k' => 'v']");
+
+    expect($args)->toBe(["['a']", "'event'", "['k' => 'v']"]);
+});


### PR DESCRIPTION
- Introduce a new `sockeon-upgrade` script for upgrading from v2 to v3, allowing for dry runs and selective upgrades of configuration and code.
- Update `SocketController` methods to align with new API calls, including renaming and restructuring for clarity.
- Add `forgetClientData` method in `HandlesClients` trait to manage client data more effectively.
- Refactor Redis client data handling with new methods for forgetting client data.
- Update `composer.json` to include the new upgrade script in the bin section.
- Enhance tests to validate the upgrade process and ensure compatibility with the new API structure.