### PR TITLE
fix upgrader false positive configs

### DIFF
--- a/bin/sockeon-upgrade
+++ b/bin/sockeon-upgrade
@@ -22,13 +22,29 @@ if (!class_exists(V2ToV3Upgrader::class)) {
     exit(1);
 }
 
-$options = getopt('', ['dry-run', 'config-only', 'code-only', 'help']);
+$flags = [
+    'dry-run' => false,
+    'config-only' => false,
+    'code-only' => false,
+    'help' => false,
+];
+
+foreach ($argv as $arg) {
+    match ($arg) {
+        '--dry-run' => $flags['dry-run'] = true,
+        '--config-only' => $flags['config-only'] = true,
+        '--code-only' => $flags['code-only'] = true,
+        '--help' => $flags['help'] = true,
+        default => null,
+    };
+}
+
 $args = array_values(array_filter(
     $argv,
     static fn (string $arg): bool => !str_starts_with($arg, '-') && $arg !== ($argv[0] ?? '')
 ));
 
-if (isset($options['help'])) {
+if ($flags['help']) {
     echo <<<HELP
 Sockeon v2 → v3 upgrade script
 
@@ -58,7 +74,7 @@ if ($path === false || (!is_dir($path) && !is_file($path))) {
     exit(1);
 }
 
-$dryRun = isset($options['dry-run']);
+$dryRun = $flags['dry-run'];
 $upgrader = new V2ToV3Upgrader();
 $write = !$dryRun;
 $results = [];
@@ -70,9 +86,9 @@ if (is_file($path)) {
         exit(1);
     }
 
-    if (isset($options['config-only'])) {
+    if ($flags['config-only']) {
         $result = $upgrader->upgradeConfig($content, $path);
-    } elseif (isset($options['code-only'])) {
+    } elseif ($flags['code-only']) {
         $result = $upgrader->upgradePhp($content, $path);
     } else {
         $php = $upgrader->upgradePhp($content, $path);
@@ -110,9 +126,9 @@ if (is_file($path)) {
             continue;
         }
 
-        if (isset($options['config-only'])) {
+        if ($flags['config-only']) {
             $result = $upgrader->upgradeConfig($content, $filePath);
-        } elseif (isset($options['code-only'])) {
+        } elseif ($flags['code-only']) {
             $result = $upgrader->upgradePhp($content, $filePath);
         } else {
             $php = $upgrader->upgradePhp($content, $filePath);

--- a/src/Upgrade/V2ToV3Upgrader.php
+++ b/src/Upgrade/V2ToV3Upgrader.php
@@ -40,7 +40,7 @@ final class V2ToV3Upgrader
         $this->changes = [];
         $original = $content;
 
-        if (!$this->looksLikeSockeonConfig($content)) {
+        if (!$this->looksLikeSockeonConfig($content, $path)) {
             return ['content' => $content, 'changes' => []];
         }
 
@@ -136,10 +136,32 @@ final class V2ToV3Upgrader
         return $results;
     }
 
-    private function looksLikeSockeonConfig(string $content): bool
+    private function looksLikeSockeonConfig(string $content, string $path = ''): bool
     {
-        return str_contains($content, 'ServerConfig')
-            || (str_contains($content, "'host'") && str_contains($content, "'port'"));
+        $normalizedPath = str_replace('\\', '/', $path);
+        if ($normalizedPath !== '' && str_ends_with($normalizedPath, 'sockeon.php')) {
+            return true;
+        }
+
+        if (str_contains($content, 'ServerConfig')) {
+            return true;
+        }
+
+        foreach ([
+            'controllers_path',
+            'maxHttpRequestsPerIp',
+            'maxMessagesPerSecond',
+            'SOCKEON_HOST',
+            'SOCKEON_PORT',
+            "'to_console'",
+            '"to_console"',
+        ] as $marker) {
+            if (str_contains($content, $marker)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private function shouldSkipPath(string $path): bool

--- a/tests/Unit/V2ToV3UpgraderTest.php
+++ b/tests/Unit/V2ToV3UpgraderTest.php
@@ -82,6 +82,24 @@ test('upgrades sockeon config defaults', function () {
         ->toContain('maxConnectionsPerIp');
 });
 
+test('does not upgrade unrelated laravel config files', function () {
+    $source = <<<'PHP'
+        <?php
+
+        return [
+            'host' => env('DB_HOST', '127.0.0.1'),
+            'port' => env('DB_PORT', '3306'),
+            'debug' => (bool) env('APP_DEBUG', false),
+        ];
+        PHP;
+
+    $upgrader = new V2ToV3Upgrader();
+    $result = $upgrader->upgradeConfig($source, 'config/database.php');
+
+    expect($result['changes'])->toBe([]);
+    expect($result['content'])->toBe($source);
+});
+
 test('call argument parser splits nested arrays', function () {
     $args = Sockeon\Sockeon\Upgrade\CallArgumentParser::split("['a'], 'event', ['k' => 'v']");
 


### PR DESCRIPTION
Refactor sockeon-upgrade script to use flags for command-line options and enhance config validation in V2ToV3Upgrader. Update tests to ensure unrelated config files are not upgraded.