### PR TITLE
fix-stream-select-eintr

### DIFF
--- a/src/Engine/StreamSelectEngine.php
+++ b/src/Engine/StreamSelectEngine.php
@@ -126,16 +126,19 @@ class StreamSelectEngine implements EngineInterface
                     fn($client) => is_resource($client)
                 );
                 $readSockets[] = $this->socket;
-                /** @var array<resource> $read */
-                $read = $readSockets;
-
-                $write = $except = null;
 
                 $clientCount = count($readSockets) - 1;
                 $timeoutSeconds = 0;
                 $timeoutMicroseconds = $clientCount === 0 ? 100000 : 10000;
 
-                $selectResult = stream_select($read, $write, $except, $timeoutSeconds, $timeoutMicroseconds);
+                do {
+                    $read = $readSockets;
+                    $write = $except = null;
+                    $selectResult = @stream_select($read, $write, $except, $timeoutSeconds, $timeoutMicroseconds);
+                } while (
+                    $selectResult === false
+                    && str_contains(error_get_last()['message'] ?? '', 'Interrupted system call')
+                );
 
                 if ($selectResult === false) {
                     $this->server->getLogger()->error('[Sockeon Engine] stream_select failed', [

--- a/tests/Unit/StreamSelectEngineTest.php
+++ b/tests/Unit/StreamSelectEngineTest.php
@@ -61,6 +61,82 @@ test('stream select engine rejects connections when max_connections is reached',
     }
 });
 
+test('stream select engine shuts down cleanly on SIGTERM without EINTR warnings', function () {
+    if (!function_exists('pcntl_signal') || !function_exists('posix_kill')) {
+        skip('pcntl/posix not available');
+    }
+
+    [$port, $reservedSocket] = reserveTestPort();
+    socket_close($reservedSocket);
+
+    $fixture = dirname(__DIR__) . '/fixtures/run_server.php';
+    $command = sprintf(
+        '%s %s %d %d %s %s',
+        escapeshellarg(PHP_BINARY),
+        escapeshellarg($fixture),
+        $port,
+        10,
+        escapeshellarg('stream_select'),
+        escapeshellarg('default'),
+    );
+
+    $descriptors = [
+        ['pipe', 'r'],
+        ['pipe', 'w'],
+        ['pipe', 'w'],
+    ];
+
+    $process = proc_open($command, $descriptors, $pipes);
+    expect($process)->toBeResource();
+
+    fclose($pipes[0]);
+    stream_set_blocking($pipes[1], false);
+    stream_set_blocking($pipes[2], false);
+
+    $deadline = microtime(true) + 10.0;
+    while (microtime(true) < $deadline) {
+        $status = proc_get_status($process);
+        expect($status['running'])->toBeTrue();
+
+        $probe = @fsockopen('127.0.0.1', $port, $errno, $errstr, 0.2);
+        if ($probe !== false) {
+            fclose($probe);
+            break;
+        }
+
+        usleep(20_000);
+    }
+
+    $socket = @fsockopen('127.0.0.1', $port, $errno, $errstr, 0.2);
+    expect($socket)->not->toBeFalse();
+    fclose($socket);
+
+    $status = proc_get_status($process);
+    posix_kill($status['pid'], SIGTERM);
+
+    $stderr = '';
+    $deadline = microtime(true) + 5.0;
+    while (microtime(true) < $deadline) {
+        $chunk = fread($pipes[2], 8192);
+        if (is_string($chunk) && $chunk !== '') {
+            $stderr .= $chunk;
+        }
+
+        $status = proc_get_status($process);
+        if (!$status['running']) {
+            break;
+        }
+
+        usleep(20_000);
+    }
+
+    fclose($pipes[1]);
+    fclose($pipes[2]);
+    proc_close($process);
+
+    expect($stderr)->not->toContain('Interrupted system call');
+});
+
 test('stream select engine accepts tcp connections in integration', function () {
     [$port, $reservedSocket] = reserveTestPort();
     socket_close($reservedSocket);


### PR DESCRIPTION
Enhance StreamSelectEngine to handle interrupted system calls during stream_select. Add a test to ensure clean shutdown on SIGTERM without EINTR warnings.